### PR TITLE
refreshToken is now obtained from db

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -187,27 +187,23 @@ describe("POST /api/auth", () => {
 })
 
 describe("POST /api/refresh-token", () => {
-  it("returns new generated tokens when passed a valid refresh token", () => {
-    const validRefreshToken = jwt.sign({ userId: "aa345ccd778fbde485ffaeda" }, process.env.REFRESH_TOKEN, { expiresIn: 60 * 15 });
+  it("returns an object with key values success:true and token: new generated token, when passed a valid refresh token", () => {
     return request(app)
     .post("/api/refresh-token")
-    .send({
-      token: validRefreshToken
-    })
+    .send({userId: "6778436ee5e8aac81fb73f15"})
     .expect(200)
     .then((res) => {
-      const result = res.body.tokens;
+      const result = res.body.newToken;
       expect(result).toHaveProperty("token")
-      expect(result).toHaveProperty("refreshToken")
+      expect(result).toMatchObject({
+        sucessNewToken: true
+      })
     })
   })
   it("returns error when passed an invalid refresh token", () => {
-    const invalidRefreshToken = "invalid"
       return request(app)
         .post("/api/refresh-token")
-        .send({
-          token: invalidRefreshToken,
-        })
+        .send({userId: "aa345ccd778fbde485ffaeda"})
         .expect(403)
         .then((res) => {
           const error = res.body;
@@ -215,25 +211,19 @@ describe("POST /api/refresh-token", () => {
         });
   })
   it("returns error when passed an expired refresh token", () => {
-    const expiredRefreshToken = jwt.sign(
-      { userId: "aa345ccd778fbde485ffaeda" },
-      process.env.REFRESH_TOKEN,
-      { expiresIn: -1 }
-    );
       return request(app)
         .post("/api/refresh-token")
-        .send({
-          token: expiredRefreshToken,
-        })
+        .send({userId: "aa345ccd778fbde485ffaeda"})
         .expect(403)
         .then((res) => {
           const error = res.body;
           expect(error.msg).toBe("Invalid or expired refresh token");
         });
   });
-  it("returns error when passed no refresh token", () => {
+  it("returns error when passed a user with no refresh token", () => {
       return request(app)
         .post("/api/refresh-token")
+        .send({userId: "abc3548cafebcf7586acde80"})
         .expect(401)
         .then((res) => {
           const error = res.body;
@@ -249,7 +239,7 @@ describe("POST /api/add-intake", () => {
     .post("/api/add-intake")
     .set("Authorization", `Bearer ${validToken}`)
     .send({
-      userId: "aa345ccd778fbde485ffaeda",
+      userId: "6778436ee5e8aac81fb73f15",
       date: today,
       kcal: 5000,
       protein: 100,
@@ -258,6 +248,7 @@ describe("POST /api/add-intake", () => {
     .expect(201)
     .then((res) => {
       const result = res.body.result
+      console.log(result)
       expect(result).toMatchObject({
         sucess: true,
         intake: {

--- a/controllers.js
+++ b/controllers.js
@@ -29,10 +29,10 @@ function loginUser(req, res, next) {
 }
 
 function createNewToken(req, res, next) {
-    const refreshToken = req.body.token;
-    generateNewToken(refreshToken)
-    .then((tokens) => {
-        res.status(200).send({ tokens })
+    const userId = req.body.userId
+    generateNewToken(userId)
+    .then((newToken) => {
+        res.status(200).send({ newToken })
     })
     .catch((err) => next(err));
 }

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,6 +1,7 @@
 const { ObjectId } = require("bson");
 const { connectToDatabase, client } = require("./dbconnect");
 const { bcryptPassword } = require("../utils");
+const jwt = require('jsonwebtoken');
 
 async function seedTestingDatabase() {
   try {
@@ -26,6 +27,11 @@ async function seedTestingDatabase() {
         email: "maria@example.com",
         password: hashPasswords[0],
         createdAt: "2025-01-01",
+        refreshToken: jwt.sign(
+          { data: "6778436ee5e8aac81fb73f15" },
+          process.env.REFRESH_TOKEN,
+          { expiresIn: "30d" }
+        ),
       },
       {
         _id: new ObjectId("aa345ccd778fbde485ffaeda"),
@@ -33,6 +39,11 @@ async function seedTestingDatabase() {
         email: "rui@example.com",
         password: hashPasswords[1],
         createdAt: "2024-12-31",
+        refreshToken: jwt.sign(
+          { userId: "aa345ccd778fbde485ffaeda" },
+          process.env.REFRESH_TOKEN,
+          { expiresIn: -1 }
+        ),
       },
       {
         _id: new ObjectId("abc3548cafebcf7586acde80"),


### PR DESCRIPTION
**Endpoint "POST /api/refresh-token" changes:**
 now instead of sending the refresh token to this endpoint, we send the userId and the refresh token is obtained from the users collection on database;
 
 **app.test.js:**
  - tests for this endpoint adapted to send the userId instead of refreshToken;

**db/seed.js:**
 - a valid and an expired refreshToken added to different users for test purposes;
 
 **controller.js:**
  - requiring userId instead of token;
  
  **models.js:**
   - find user by userID on users collection on db;
   - if that user has no refreshToken, return error;
   - return error if token is not verified;
   - finally, if successful return an object with key value sucessNewToken: true and token reflecting new token generated;
