### PR TITLE
Get intake

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -5,6 +5,7 @@ const { client } = require("../db/dbconnect.js");
 const jwt = require('jsonwebtoken');
 const { selectIntakeByDate } = require("../models.js");
 const endpoints = require("../endpoints.json");
+const { ObjectId } = require("bson");
 
 beforeEach(async () => {
   await seedTestingDatabase();
@@ -60,7 +61,7 @@ function testForTokens(method, endpoint, body) {
 
 
 describe("GET /api/:date", () => {
-    it("returns an object with date, currIntake and intakes containing kcal, protein and carb properties when passed valid userId and valid date. code 200", () => {
+    it.only("returns an object with date, currIntake and intakes containing kcal, protein and carb properties when passed valid userId and valid date. code 200", () => {
       return request(app)
         .get("/api/2024-12-31")
         .set("Authorization", `Bearer ${validToken}`)
@@ -68,7 +69,9 @@ describe("GET /api/:date", () => {
         .expect(200)
         .then((res) => {
           const intake = res.body;
+          console.log(intake)
           expect(intake).toEqual({
+            _id: "67dc45661f28ee4810c32037",
             date: "2024-12-31",
             currIntake: {
               kcal: 3679,

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -61,7 +61,7 @@ function testForTokens(method, endpoint, body) {
 
 
 describe("GET /api/:date", () => {
-    it.only("returns an object with date, currIntake and intakes containing kcal, protein and carb properties when passed valid userId and valid date. code 200", () => {
+    it("returns an object with date, currIntake and intakes containing kcal, protein and carb properties when passed valid userId and valid date. code 200", () => {
       return request(app)
         .get("/api/2024-12-31")
         .set("Authorization", `Bearer ${validToken}`)
@@ -69,7 +69,6 @@ describe("GET /api/:date", () => {
         .expect(200)
         .then((res) => {
           const intake = res.body;
-          console.log(intake)
           expect(intake).toEqual({
             _id: "67dc45661f28ee4810c32037",
             date: "2024-12-31",

--- a/db/seed.js
+++ b/db/seed.js
@@ -66,6 +66,7 @@ async function seedTestingDatabase() {
     const intakeDocs = [
       {
         userId: "6778436ee5e8aac81fb73f15",
+        _id: new ObjectId("67dc45661f28ee4810c32038"),
         date: "2025-01-01",
         currIntake: {
           kcal: 2000,
@@ -81,6 +82,7 @@ async function seedTestingDatabase() {
       },
       {
         userId: "6778436ee5e8aac81fb73f15",
+        _id: new ObjectId("67dc45661f28ee4810c32039"),
         date: "2024-01-31",
         currIntake: {
           kcal: 2220,
@@ -96,6 +98,7 @@ async function seedTestingDatabase() {
       },
       {
         userId: "6778436ee5e8aac81fb73f15",
+        _id: new ObjectId("67dc45661f28ee4810c32031"),
         date: "2024-01-30",
         currIntake: {
           kcal: 3196,
@@ -111,6 +114,7 @@ async function seedTestingDatabase() {
       },
       {
         userId: "aa345ccd778fbde485ffaeda",
+        _id: new ObjectId("67dc45661f28ee4810c32037"),
         date: "2024-12-31",
         currIntake: {
           kcal: 3679,
@@ -126,6 +130,7 @@ async function seedTestingDatabase() {
       },
       {
         userId: "aa345ccd778fbde485ffaeda",
+        _id: new ObjectId("67dc45661f28ee4810c32032"),
         date: new Date().toISOString().slice(0, 10),
         currIntake: {
           kcal: 3123,
@@ -141,6 +146,7 @@ async function seedTestingDatabase() {
       },
       {
         userId: "abc3548cafebcf7586acde8",
+        _id: new ObjectId("67dc45661f28ee4810c32033"),
         date: "2024-12-25",
         currIntake: {
           kcal: 2789,
@@ -156,6 +162,7 @@ async function seedTestingDatabase() {
       },
       {
         userId: "abc3548cafebcf7586acde8",
+        _id: new ObjectId("67dc45661f28ee4810c32034"),
         date: "2025-01-01",
         currIntake: {
           kcal: 3001,
@@ -171,6 +178,7 @@ async function seedTestingDatabase() {
       },
       {
         userId: "684abefee8356aceaff74bb4",
+        _id: new ObjectId("67dc45661f28ee4810c32035"),
         date: "2025-01-02",
         currIntake: {
           kcal: 2000,

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,6 +11,7 @@
         "userId": "7664566aa5e8aab81fb89b69"
     },
     "exampleResponse": {
+      "_id": "67dc45661f28ee4810c32037",
       "date": "2025-01-31",
       "currIntake": {
         "kcal": 1001,

--- a/models.js
+++ b/models.js
@@ -20,7 +20,7 @@ async function selectIntakeByDate(userId, date) {
             const db = client.db("myIntake");
             const intakes = db.collection("intakes");
             const options = {
-                projection: { _id:0, date: 1, currIntake: 1, intakes: 1}
+                projection: { _id:1, date: 1, currIntake: 1, intakes: 1}
             }
             const intake = await intakes.findOne({$and : [{userId: userId}, {date: date}]}, options)
             if (!intake) {


### PR DESCRIPTION
In order to be able to access the daily intakes and edit them in the future endpoint to be created, changes were made so the id is retrieved when calling the endpoint "/api/:date".

**db/seed.js:**
 - when seeding the db, the intakeDocs contain _id now;

**models.js:**
 - on the function selectIntakeByDate, the projections were altered to retrieve the id;
 
**app.test.js:**
 - when testing for "/api/:date", the object expected is to have _id property;

**endpoints.js:**
 - GET /api/:date endpoint altered accordingly;