### PR TITLE
remove userId on the returned object

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -539,7 +539,6 @@ describe("PUT /api/edit-intake", () => {
       expect(editedIntake).toEqual({
         success: true,
         msg: "intake edited successfully",
-        userId: "aa345ccd778fbde485ffaeda",
         _id: "67dc45661f28ee4810c32032",
         date: new Date().toISOString().slice(0, 10),
         currIntake: {

--- a/models.js
+++ b/models.js
@@ -329,11 +329,9 @@ async function editTodayIntake(userId, intakeId, intakeIndex, newIntake) {
         }
       )
       if (updatedIntake.modifiedCount === 1) {
-        console.log("HEYY")
         return {
           success: true,
           msg: "intake edited successfully",
-          userId: foundIntake.userId,
           _id: foundIntake._id,
           date: foundIntake.date,
           currIntake: intakeTotals,


### PR DESCRIPTION
for the PUT /api/get-intake endpoint the userId was removed on the returned object since it is unnecessary and it could compromise security;

console.log removed;